### PR TITLE
Modify add thread operation to allow adding thread with a new tag

### DIFF
--- a/src/java/com/google/tagpost/TagpostClient.java
+++ b/src/java/com/google/tagpost/TagpostClient.java
@@ -12,7 +12,7 @@ import com.google.common.flogger.FluentLogger;
 public class TagpostClient {
   static final String TAG = "noise";
   static final String PRIMARY_TAG = "testTag";
-  static final String THREAD_ID_EXAMPLE = "12bd2b80-5f47-4367-b0b3-ec0a00ddb271";
+  static final String THREAD_ID_EXAMPLE = "bc7e5745-c65c-4da5-9fd7-3c79d2c0f25f";
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private final TagpostServiceGrpc.TagpostServiceBlockingStub blockingStub;
 
@@ -65,7 +65,10 @@ public class TagpostClient {
         "Client will try to send request to add a new thread with PrimaryTag = " + primaryTag);
 
     Thread thread =
-        Thread.newBuilder().setPrimaryTag(Tag.newBuilder().setTagName(primaryTag).build()).build();
+        Thread.newBuilder()
+            .setTopic("This is a default thread topic.")
+            .setPrimaryTag(Tag.newBuilder().setTagName(primaryTag).build())
+            .build();
 
     AddThreadWithTagRequest request =
         AddThreadWithTagRequest.newBuilder().setThread(thread).build();

--- a/src/java/com/google/tagpost/TagpostClient.java
+++ b/src/java/com/google/tagpost/TagpostClient.java
@@ -31,6 +31,7 @@ public class TagpostClient {
     try {
       TagpostClient client = new TagpostClient(channel);
       client.requestAddNewThread(TAG);
+      client.requestAddNewThread(PRIMARY_TAG);
       client.requestFetchThreads(TAG);
       client.requestAddNewComment(THREAD_ID_EXAMPLE);
       client.requestFetchComments(THREAD_ID_EXAMPLE);

--- a/src/java/com/google/tagpost/spanner/SpannerService.java
+++ b/src/java/com/google/tagpost/spanner/SpannerService.java
@@ -52,6 +52,7 @@ public class SpannerService implements DataService {
   @Override
   public Thread addNewThreadWithTag(Thread thread) {
     String threadId = UUID.randomUUID().toString();
+    Timestamp timestamp = Timestamp.now();
 
     Mutation mutation =
         Mutation.newInsertBuilder("Thread")
@@ -59,6 +60,10 @@ public class SpannerService implements DataService {
             .to(thread.getPrimaryTag().getTagName())
             .set("ThreadID")
             .to(threadId)
+            .set("Topic")
+            .to(thread.getTopic())
+            .set("Timestamp")
+            .to(timestamp)
             .build();
 
     dbClient.write(ImmutableList.of(mutation));

--- a/src/java/com/google/tagpost/spanner/SpannerService.java
+++ b/src/java/com/google/tagpost/spanner/SpannerService.java
@@ -8,6 +8,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.SpannerException;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Singleton;
@@ -53,6 +54,15 @@ public class SpannerService implements DataService {
   public Thread addNewThreadWithTag(Thread thread) {
     String threadId = UUID.randomUUID().toString();
     Timestamp timestamp = Timestamp.now();
+    String tagName = thread.getPrimaryTag().getTagName();
+
+    // Add a new tag entry in Tag table if tagName not yet existed
+    Mutation tagMutation = Mutation.newInsertBuilder("Tag").set("TagName").to(tagName).build();
+    try {
+      dbClient.write(ImmutableList.of(tagMutation));
+    } catch (SpannerException ok) {
+      // SpannerException is expected to be caught here for adding an already existed TagName
+    }
 
     Mutation mutation =
         Mutation.newInsertBuilder("Thread")

--- a/src/proto/tagpost.proto
+++ b/src/proto/tagpost.proto
@@ -15,6 +15,8 @@ message Tag {
 message Thread {
   string thread_id = 1;
   Tag primary_tag = 2;
+  string topic = 3;
+  google.protobuf.Timestamp timestamp = 4;
 }
 
 message Comment {

--- a/src/proto/tagpost_rpc.proto
+++ b/src/proto/tagpost_rpc.proto
@@ -53,7 +53,6 @@ message FetchCommentsUnderThreadResponse {
   repeated Comment comment = 1;
 }
 
-
 message AddCommentUnderThreadRequest {
   /*
   Fields required to be filled in the request:

--- a/src/proto/tagpost_rpc.proto
+++ b/src/proto/tagpost_rpc.proto
@@ -36,7 +36,7 @@ message FetchThreadsByTagResponse {
 message AddThreadWithTagRequest {
   /*
   Fields required to be filled in the request:
-  primary_tag
+  primary_tag, topic
   */
   Thread thread = 1;
 }


### PR DESCRIPTION
This PR depends on #31 
### Change:
- Previously, tagpost server would not allow adding a new thread with a tag that does not has a entry in database. With this PR, tagpost server will allow adding a new thread with a new tag by inserting this new tag into Tag Table in database. 
- Modified ``addNewThreadWithTag`` in ``SpannerService`` to allow adding new tag when creating thread with a new tag that does not exist in Tag Table.