### PR TITLE
Use chart to show TagStat 

### DIFF
--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.html
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.html
@@ -1,0 +1,1 @@
+<div id="donutchart"></div>

--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.html
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.html
@@ -1,1 +1,1 @@
-<div id="donutchart"></div>
+<div #donutChart></div>

--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
@@ -1,0 +1,44 @@
+import {Component, OnInit} from '@angular/core';
+
+import {GoogleChartService} from 'app/google-chart/google-chart.service';
+
+@Component({
+  selector: 'app-donut-chart',
+  templateUrl: './donut-chart.component.html',
+  styleUrls: ['./donut-chart.component.sass']
+})
+export class DonutChartComponent implements OnInit {
+
+  private library: any;
+
+  constructor(private chartService: GoogleChartService) {
+    this.library = this.chartService.getGoogle();
+    this.library.charts.load('current', { packages: ['corechart'] });
+    this.library.charts.setOnLoadCallback(this.drawChart.bind(this));
+  }
+
+  ngOnInit(): void {
+  }
+
+  private drawChart(): void {
+    const chart = new this.library.visualization.PieChart(document.getElementById('donutchart'));
+    const data = new this.library.visualization.arrayToDataTable([
+      ['Category', 'Vote'],
+      ['noise', 20],
+      ['other', 2],
+      ['undefined', 1],
+    ]);
+
+    const options = {
+      pieHole: 0.4,
+      fontSize: 14,
+      chartArea: { width: '90%', height: '90%' },
+      width: 450,
+      height: 400,
+      legend: { position: 'left' },
+      backgroundColor: '#eef6fc'
+    };
+    chart.draw(data, options);
+  }
+
+}

--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
@@ -1,7 +1,6 @@
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, ElementRef, Input, OnInit, ViewChild} from '@angular/core';
 
 import {GoogleChartService} from 'app/google-chart/google-chart.service';
-import {DataService} from 'app/service/data.service';
 import {TagStats} from 'compiled_proto/src/proto/tagpost_pb';
 
 @Component({
@@ -16,6 +15,7 @@ export class DonutChartComponent implements OnInit {
 
   private library;
   @Input() tagStats: TagStats; // Input passed from ThreadDetailComponent
+  @ViewChild('donutChart') donutChart: ElementRef;
 
   constructor(private chartService: GoogleChartService) {
     this.library = this.chartService.getGoogle();
@@ -27,7 +27,7 @@ export class DonutChartComponent implements OnInit {
   }
 
   private drawChart(): void {
-    const chart = new this.library.visualization.PieChart(document.getElementById('donutchart'));
+    const chart = new this.library.visualization.PieChart(this.donutChart.nativeElement);
 
     const data = new this.library.visualization.DataTable();
     data.addColumn('string', 'Category');

--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
@@ -19,8 +19,7 @@ export class DonutChartComponent implements OnInit {
 
   constructor(private chartService: GoogleChartService) {
     this.library = this.chartService.getGoogle();
-    this.library.charts.load('current', { packages: ['corechart'] });
-    this.library.charts.setOnLoadCallback(this.drawChart.bind(this));
+    this.chartService.loadChart().then(this.drawChart.bind(this));
   }
 
   ngOnInit(): void {
@@ -45,5 +44,4 @@ export class DonutChartComponent implements OnInit {
     };
     chart.draw(data, options);
   }
-
 }

--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
@@ -1,33 +1,42 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 
 import {GoogleChartService} from 'app/google-chart/google-chart.service';
+import {DataService} from 'app/service/data.service';
+import {TagStats} from 'compiled_proto/src/proto/tagpost_pb';
 
 @Component({
   selector: 'app-donut-chart',
   templateUrl: './donut-chart.component.html',
   styleUrls: ['./donut-chart.component.sass']
 })
+/**
+ * A donut chart component to visualize TagStats
+ */
 export class DonutChartComponent implements OnInit {
 
-  private library: any;
+  private library;
+  private tagStats: TagStats;
 
-  constructor(private chartService: GoogleChartService) {
+  constructor(private chartService: GoogleChartService,
+              private dataService: DataService) {
     this.library = this.chartService.getGoogle();
     this.library.charts.load('current', { packages: ['corechart'] });
     this.library.charts.setOnLoadCallback(this.drawChart.bind(this));
   }
 
   ngOnInit(): void {
+    this.dataService.tagStats.subscribe((tagStats) => {
+      this.tagStats = tagStats;
+    });
   }
 
   private drawChart(): void {
     const chart = new this.library.visualization.PieChart(document.getElementById('donutchart'));
-    const data = new this.library.visualization.arrayToDataTable([
-      ['Category', 'Vote'],
-      ['noise', 20],
-      ['other', 2],
-      ['undefined', 1],
-    ]);
+
+    const data = new this.library.visualization.DataTable();
+    data.addColumn('string', 'Category');
+    data.addColumn('number', 'vote');
+    data.addRows(this.tagStats.getStatisticsMap().arr_);
 
     const options = {
       pieHole: 0.4,

--- a/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
+++ b/ui/src/app/google-chart/donut-chart/donut-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 
 import {GoogleChartService} from 'app/google-chart/google-chart.service';
 import {DataService} from 'app/service/data.service';
@@ -15,19 +15,15 @@ import {TagStats} from 'compiled_proto/src/proto/tagpost_pb';
 export class DonutChartComponent implements OnInit {
 
   private library;
-  private tagStats: TagStats;
+  @Input() tagStats: TagStats; // Input passed from ThreadDetailComponent
 
-  constructor(private chartService: GoogleChartService,
-              private dataService: DataService) {
+  constructor(private chartService: GoogleChartService) {
     this.library = this.chartService.getGoogle();
     this.library.charts.load('current', { packages: ['corechart'] });
     this.library.charts.setOnLoadCallback(this.drawChart.bind(this));
   }
 
   ngOnInit(): void {
-    this.dataService.tagStats.subscribe((tagStats) => {
-      this.tagStats = tagStats;
-    });
   }
 
   private drawChart(): void {

--- a/ui/src/app/google-chart/google-chart.module.ts
+++ b/ui/src/app/google-chart/google-chart.module.ts
@@ -1,0 +1,16 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {DonutChartComponent} from 'app/google-chart/donut-chart/donut-chart.component';
+
+@NgModule({
+  declarations: [DonutChartComponent],
+  imports: [
+    CommonModule
+  ],
+  exports: [
+    DonutChartComponent
+  ]
+})
+export class GoogleChartModule {
+}

--- a/ui/src/app/google-chart/google-chart.service.ts
+++ b/ui/src/app/google-chart/google-chart.service.ts
@@ -12,7 +12,6 @@ export class GoogleChartService {
 
   private readonly google: any;
   private loaderPromise: Promise<any>;
-  number = 1;
 
   constructor() {
     this.google = google;

--- a/ui/src/app/google-chart/google-chart.service.ts
+++ b/ui/src/app/google-chart/google-chart.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+
+declare var google: any;
+
+/**
+ * Service to access Google Chart library
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class GoogleChartService {s
+
+  private readonly google: any;
+
+  constructor() {
+    this.google = google;
+  }
+
+  getGoogle(): any {
+    return this.google;
+  }
+}

--- a/ui/src/app/google-chart/google-chart.service.ts
+++ b/ui/src/app/google-chart/google-chart.service.ts
@@ -11,6 +11,8 @@ declare var google: any;
 export class GoogleChartService {
 
   private readonly google: any;
+  private loaderPromise: Promise<any>;
+  number = 1;
 
   constructor() {
     this.google = google;
@@ -18,5 +20,13 @@ export class GoogleChartService {
 
   getGoogle(): any {
     return this.google;
+  }
+
+  loadChart(): Promise<any> {
+    // Load Google Chart library only when library is not loaded.
+    if (!this.loaderPromise) {
+      this.loaderPromise = google.charts.load('current', { packages: ['corechart'] });
+    }
+    return this.loaderPromise;
   }
 }

--- a/ui/src/app/google-chart/google-chart.service.ts
+++ b/ui/src/app/google-chart/google-chart.service.ts
@@ -8,7 +8,7 @@ declare var google: any;
 @Injectable({
   providedIn: 'root'
 })
-export class GoogleChartService {s
+export class GoogleChartService {
 
   private readonly google: any;
 

--- a/ui/src/app/panel/thread-detail/thread-detail.component.html
+++ b/ui/src/app/panel/thread-detail/thread-detail.component.html
@@ -1,7 +1,7 @@
 <!-- Message box to show a donut chart of TagStats -->
 <article class="message is-info">
   <div class="message-body">
-    <app-donut-chart><</app-donut-chart>
+    <app-donut-chart></app-donut-chart>
   </div>
 </article>
 

--- a/ui/src/app/panel/thread-detail/thread-detail.component.html
+++ b/ui/src/app/panel/thread-detail/thread-detail.component.html
@@ -1,9 +1,20 @@
-<!-- Message box to show a donut chart of TagStats -->
-<article class="message is-info">
-  <div class="message-body">
-    <app-donut-chart></app-donut-chart>
-  </div>
-</article>
+<ng-container *ngIf="(tagStats$ | async) as tagStats">
+  <!-- Message box to show a donut chart of TagStats -->
+  <article class="message is-info" *ngIf="tagStats.getStatisticsMap().arr_.length > 0 else noData">
+    <div class="message-body">
+      <app-donut-chart [tagStats]="tagStats">
+      </app-donut-chart>
+    </div>
+  </article>
+  <!-- Message box to show notification when no statistics available -->
+  <ng-template #noData>
+    <article class="message is-warning">
+      <div class="message-body">
+        No tag statistic found for <strong> {{tagStats.getTag()}} </strong>
+      </div>
+    </article>
+  </ng-template>
+</ng-container>
 
 <!-- Show a list of comments under thread -->
 <div *ngIf="(commentList$ | async) as commentList">

--- a/ui/src/app/panel/thread-detail/thread-detail.component.ts
+++ b/ui/src/app/panel/thread-detail/thread-detail.component.ts
@@ -6,7 +6,7 @@ import {switchMap} from 'rxjs/operators';
 
 import {DataService} from 'app/service/data.service';
 import {convertTimestamp} from 'app/service/utils';
-import {Comment} from 'compiled_proto/src/proto/tagpost_pb';
+import {Comment, TagStats} from 'compiled_proto/src/proto/tagpost_pb';
 
 @Component({
   selector: 'app-thread-detail',
@@ -18,6 +18,7 @@ import {Comment} from 'compiled_proto/src/proto/tagpost_pb';
  */
 export class ThreadDetailComponent implements OnInit {
   commentList$: Observable<Array<Comment>>;
+  tagStats$: Observable<TagStats>;
   convertTimestamp = convertTimestamp;
 
   constructor(
@@ -31,8 +32,13 @@ export class ThreadDetailComponent implements OnInit {
     this.commentList$ = this.route.paramMap.pipe(
       switchMap(params => {
         this.dataService.fetchComments(params.get('id'));
-        this.dataService.fetchTagStats(params.get('tagName'))
         return this.dataService.commentList;
+      })
+    );
+    this.tagStats$ = this.route.paramMap.pipe(
+      switchMap(params => {
+        this.dataService.fetchTagStats(params.get('tagName'));
+        return this.dataService.tagStats;
       })
     );
   }

--- a/ui/src/app/panel/thread-detail/thread-detail.component.ts
+++ b/ui/src/app/panel/thread-detail/thread-detail.component.ts
@@ -30,7 +30,8 @@ export class ThreadDetailComponent implements OnInit {
   ngOnInit(): void {
     this.commentList$ = this.route.paramMap.pipe(
       switchMap(params => {
-        this.dataService.fetchComments(this.route.snapshot.params.id);
+        this.dataService.fetchComments(params.get('id'));
+        this.dataService.fetchTagStats(params.get('tagName'))
         return this.dataService.commentList;
       })
     );

--- a/ui/src/app/panel/thread-list/thread-list.component.html
+++ b/ui/src/app/panel/thread-list/thread-list.component.html
@@ -7,7 +7,7 @@
         <div class="level-left">
           <div class="level-item">
             <div class="thread">
-              <a [routerLink]="['/thread', thread.getThreadId()]">
+              <a [routerLink]="['/thread', thread.getThreadId(), {tagName: thread.getPrimaryTag().getTagName()}]">
                 <p><strong>{{thread.getTopic()}}</strong>
                 </p>
               </a>

--- a/ui/src/app/service/data.service.ts
+++ b/ui/src/app/service/data.service.ts
@@ -8,9 +8,11 @@ import {
   AddThreadWithTagRequest,
   AddThreadWithTagResponse,
   FetchCommentsUnderThreadRequest,
+  FetchCommentsUnderThreadResponse,
   FetchThreadsByTagRequest,
   FetchThreadsByTagResponse,
-  GetTagStatsRequest
+  GetTagStatsRequest,
+  GetTagStatsResponse
 } from 'compiled_proto/src/proto/tagpost_rpc_pb';
 import {environment} from 'environments/environment';
 
@@ -48,7 +50,8 @@ export class DataService {
     req.setTag(tag);
     this.client.fetchThreadsByTag(req, {}, (err, response: FetchThreadsByTagResponse) => {
       if (err) {
-        console.error(err);
+        console.error(err.code, err.message);
+        alert(err.message);
       }
       if (response) {
         this.threadListSource.next(response.getThreadsList());
@@ -90,9 +93,10 @@ export class DataService {
   fetchComments(threadId: string): void {
     const req = new FetchCommentsUnderThreadRequest();
     req.setThreadId(threadId);
-    this.client.fetchCommentsUnderThread(req, {}, (err, response) => {
+    this.client.fetchCommentsUnderThread(req, {}, (err, response: FetchCommentsUnderThreadResponse) => {
       if (err) {
         console.error(err.code, err.message);
+        alert(err.message);
       }
       if (response) {
         this.commentListSource.next(response.getCommentList());
@@ -107,9 +111,10 @@ export class DataService {
   fetchTagStats(tag: string): void {
     const req = new GetTagStatsRequest();
     req.setTag(tag);
-    this.client.getTagStats(req, {}, (err, response) => {
+    this.client.getTagStats(req, {}, (err, response: GetTagStatsResponse) => {
       if (err) {
         console.error(err.code, err.message);
+        alert(err.message);
       }
       if (response) {
         this.tagStatsSource.next(response.getStats());

--- a/ui/src/app/service/data.service.ts
+++ b/ui/src/app/service/data.service.ts
@@ -9,7 +9,8 @@ import {
   AddThreadWithTagResponse,
   FetchCommentsUnderThreadRequest,
   FetchThreadsByTagRequest,
-  FetchThreadsByTagResponse, GetTagStatsRequest
+  FetchThreadsByTagResponse,
+  GetTagStatsRequest
 } from 'compiled_proto/src/proto/tagpost_rpc_pb';
 import {environment} from 'environments/environment';
 


### PR DESCRIPTION
### Changes:
- Added a google chart module and ``donut-chart`` component to use google chart library. 
- Added ``fetchTagStats`` in ``DataService`` to fetch TagStats from backend service.
- Modified ``thread-detail.component.html``. When tagStats is available and non-empty, a donut chart will be rendered. When no tagStats is available, a notification will show. 

### Screenshot:
- Show a donut chart when tagStats is available.
![screencapture-localhost-4200-thread-a159fe63-6b40-4e3d-9978-c0af9bfab1cb-tagName-testTag-2020-08-04-01_12_11](https://user-images.githubusercontent.com/61160875/89241915-bba0d080-d5ef-11ea-8991-a2200e0efac9.png)


- Show a notification if no tagStats found for the given tag.
![screencapture-localhost-4200-thread-0ad0ff0c-9e4b-492c-a291-5cb7cd786fd2-tagName-noise-2020-08-04-01_11_45](https://user-images.githubusercontent.com/61160875/89241947-d6734500-d5ef-11ea-8c1a-6ac4e8fc247c.png)
