### PR TITLE
Set primaryTag for tagStats

### DIFF
--- a/src/java/com/google/tagpost/TagpostClient.java
+++ b/src/java/com/google/tagpost/TagpostClient.java
@@ -111,10 +111,10 @@ public class TagpostClient {
         "Client will try to send request to add a new comment under thread with threadId = "
             + threadId);
 
+    // thread_id, comment_content, username, extra_tags is required to be filled in the request
     Comment comment =
         Comment.newBuilder()
             .setUsername("client")
-            .setPrimaryTag(Tag.newBuilder().setTagName("noise").build())
             .addExtraTags(Tag.newBuilder().setTagName("test").build())
             .setCommentContent("new comment")
             .setThreadId(threadId)

--- a/src/java/com/google/tagpost/spanner/SpannerService.java
+++ b/src/java/com/google/tagpost/spanner/SpannerService.java
@@ -99,6 +99,18 @@ public class SpannerService implements DataService {
     String commentId = UUID.randomUUID().toString();
     Timestamp timestamp = Timestamp.now();
 
+    // Retrieve primaryTagName from Thread table
+    String primaryTagName = "";
+    String SQLStatement = "SELECT PrimaryTag FROM Thread WHERE ThreadID = @threadId";
+    Statement statement =
+        Statement.newBuilder(SQLStatement).bind("threadId").to(comment.getThreadId()).build();
+
+    try (ResultSet resultSet = dbClient.singleUse().executeQuery(statement)) {
+      while (resultSet.next()) {
+        primaryTagName = resultSet.getString("PrimaryTag");
+      }
+    }
+
     Mutation mutation =
         Mutation.newInsertBuilder("Comment")
             .set("CommentID")
@@ -112,7 +124,7 @@ public class SpannerService implements DataService {
             .set("ThreadID")
             .to(comment.getThreadId())
             .set("PrimaryTag")
-            .to(comment.getPrimaryTag().getTagName())
+            .to(primaryTagName)
             .set("ExtraTags")
             .toStringArray(
                 comment.getExtraTagsList().stream()

--- a/src/java/com/google/tagpost/spanner/SpannerService.java
+++ b/src/java/com/google/tagpost/spanner/SpannerService.java
@@ -196,6 +196,7 @@ public class SpannerService implements DataService {
       Map<String, Integer> statsMap = new Gson().fromJson(jsonStats, mapType);
 
       stats.putAllStatistics(statsMap);
+      stats.setTag(Tag.newBuilder().setTagName(resultSet.getString("PrimaryTag")).build());
     }
     return stats.build();
   }

--- a/src/java/com/google/tagpost/spanner/SpannerService.java
+++ b/src/java/com/google/tagpost/spanner/SpannerService.java
@@ -99,15 +99,15 @@ public class SpannerService implements DataService {
     String commentId = UUID.randomUUID().toString();
     Timestamp timestamp = Timestamp.now();
 
-    // Retrieve primaryTagName from Thread table
-    String primaryTagName = "";
+    // retrieve primaryTagName from Thread table
+    String primaryTag = "";
     String SQLStatement = "SELECT PrimaryTag FROM Thread WHERE ThreadID = @threadId";
     Statement statement =
         Statement.newBuilder(SQLStatement).bind("threadId").to(comment.getThreadId()).build();
 
     try (ResultSet resultSet = dbClient.singleUse().executeQuery(statement)) {
       while (resultSet.next()) {
-        primaryTagName = resultSet.getString("PrimaryTag");
+        primaryTag = resultSet.getString("PrimaryTag");
       }
     }
 
@@ -124,7 +124,7 @@ public class SpannerService implements DataService {
             .set("ThreadID")
             .to(comment.getThreadId())
             .set("PrimaryTag")
-            .to(primaryTagName)
+            .to(primaryTag)
             .set("ExtraTags")
             .toStringArray(
                 comment.getExtraTagsList().stream()

--- a/src/proto/tagpost_rpc.proto
+++ b/src/proto/tagpost_rpc.proto
@@ -56,7 +56,7 @@ message FetchCommentsUnderThreadResponse {
 message AddCommentUnderThreadRequest {
   /*
   Fields required to be filled in the request:
-  thread_id, comment_content, username, extra_tags
+  thread_id, comment_content, username, primary_tag, extra_tags
   */
   Comment comment = 1;
 }

--- a/src/proto/tagpost_rpc.proto
+++ b/src/proto/tagpost_rpc.proto
@@ -56,7 +56,7 @@ message FetchCommentsUnderThreadResponse {
 message AddCommentUnderThreadRequest {
   /*
   Fields required to be filled in the request:
-  thread_id, comment_content, username, primary_tag, extra_tags
+  thread_id, comment_content, username, extra_tags
   */
   Comment comment = 1;
 }


### PR DESCRIPTION
## Changes:
- Previously in ``SpannerService``, primaryTag was not set when building tagStat from Spanner response. Assigned primaryTag to tagStats.
- ~~Modified the comment for ``AddCommentUnderThreadRequest``~~
- When sending ``AddCommentUnderThreadRequest``,  the primary tag field will be retrieved by querying the Thread table in Spanner using threadId.