### PR TITLE
Add try_files in nginx config to serve up index.html

### DIFF
--- a/ui/nginx_conf/default.conf.template
+++ b/ui/nginx_conf/default.conf.template
@@ -19,6 +19,7 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
     }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
## Changes:
- Fix 404 error on reloading page by adding ``try_files`` to let Nginx forward request to index.html